### PR TITLE
Stored, sent and received data assets are always processed

### DIFF
--- a/cmd/raa/main.go
+++ b/cmd/raa/main.go
@@ -167,12 +167,14 @@ func calculateAttackerAttractiveness(input *types.ParsedModel, techAsset types.T
 		score += dataAsset.Integrity.AttackerAttractivenessForProcessedOrStoredData() * dataAsset.Quantity.QuantityFactor()
 		score += dataAsset.Availability.AttackerAttractivenessForProcessedOrStoredData()
 	}
+	// NOTE: Assuming all stored data is also processed, this effectively scores stored data twice
 	for _, dataAssetStored := range techAsset.DataAssetsStored {
 		dataAsset := input.DataAssets[dataAssetStored]
 		score += dataAsset.Confidentiality.AttackerAttractivenessForProcessedOrStoredData() * dataAsset.Quantity.QuantityFactor()
 		score += dataAsset.Integrity.AttackerAttractivenessForProcessedOrStoredData() * dataAsset.Quantity.QuantityFactor()
 		score += dataAsset.Availability.AttackerAttractivenessForProcessedOrStoredData()
 	}
+	// NOTE: To send or receive data effectively is processing that data and it's questionable if the attractiveness increases further
 	for _, dataFlow := range techAsset.CommunicationLinks {
 		for _, dataAssetSent := range dataFlow.DataAssetsSent {
 			dataAsset := input.DataAssets[dataAssetSent]

--- a/pkg/report/colors.go
+++ b/pkg/report/colors.go
@@ -367,17 +367,11 @@ func determineTechnicalAssetLabelColor(ta types.TechnicalAsset, model *types.Par
 
 // red when mission-critical integrity, but still unauthenticated (non-readonly) channels access it
 // amber when critical integrity, but still unauthenticated (non-readonly) channels access it
-// pink when model forgery attempt (i.e. nothing being processed or stored)
-
+// pink when model forgery attempt (i.e. nothing being processed)
 func determineShapeBorderColor(ta types.TechnicalAsset, parsedModel *types.ParsedModel) string {
 	// Check for red
 	if ta.Confidentiality == types.StrictlyConfidential {
 		return Red
-	}
-	for _, storedDataAsset := range ta.DataAssetsStored {
-		if parsedModel.DataAssets[storedDataAsset].Confidentiality == types.StrictlyConfidential {
-			return Red
-		}
 	}
 	for _, processedDataAsset := range ta.DataAssetsProcessed {
 		if parsedModel.DataAssets[processedDataAsset].Confidentiality == types.StrictlyConfidential {
@@ -387,11 +381,6 @@ func determineShapeBorderColor(ta types.TechnicalAsset, parsedModel *types.Parse
 	// Check for amber
 	if ta.Confidentiality == types.Confidential {
 		return Amber
-	}
-	for _, storedDataAsset := range ta.DataAssetsStored {
-		if parsedModel.DataAssets[storedDataAsset].Confidentiality == types.Confidential {
-			return Amber
-		}
 	}
 	for _, processedDataAsset := range ta.DataAssetsProcessed {
 		if parsedModel.DataAssets[processedDataAsset].Confidentiality == types.Confidential {
@@ -427,7 +416,7 @@ func determineShapeBorderColor(ta types.TechnicalAsset, parsedModel *types.Parse
 // dotted when model forgery attempt (i.e. nothing being processed or stored)
 
 func determineShapeBorderLineStyle(ta types.TechnicalAsset) string {
-	if len(ta.DataAssetsProcessed) == 0 && len(ta.DataAssetsStored) == 0 || ta.OutOfScope {
+	if len(ta.DataAssetsProcessed) == 0 || ta.OutOfScope {
 		return "dotted" // dotted, because it's strange when too many technical communication links transfer no data... some ok, but many in a diagram ist a sign of model forgery...
 	}
 	return "solid"

--- a/pkg/security/risks/builtin/accidental-secret-leak-rule.go
+++ b/pkg/security/risks/builtin/accidental-secret-leak-rule.go
@@ -29,7 +29,7 @@ func (*AccidentalSecretLeakRule) Category() types.RiskCategory {
 		Function:                   types.Operations,
 		STRIDE:                     types.InformationDisclosure,
 		DetectionLogic:             "In-scope sourcecode repositories and artifact registries.",
-		RiskAssessment:             "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment:             "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives:             "Usually no false positives.",
 		ModelFailurePossibleReason: false,
 		CWE:                        200,

--- a/pkg/security/risks/builtin/container-platform-escape-rule.go
+++ b/pkg/security/risks/builtin/container-platform-escape-rule.go
@@ -34,7 +34,7 @@ func (*ContainerPlatformEscapeRule) Category() types.RiskCategory {
 		Function:       types.Operations,
 		STRIDE:         types.ElevationOfPrivilege,
 		DetectionLogic: "In-scope container platforms.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Container platforms not running parts of the target architecture can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/cross-site-scripting-rule.go
+++ b/pkg/security/risks/builtin/cross-site-scripting-rule.go
@@ -27,7 +27,7 @@ func (*CrossSiteScriptingRule) Category() types.RiskCategory {
 		Function:       types.Development,
 		STRIDE:         types.Tampering,
 		DetectionLogic: "In-scope web applications.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the data processed or stored in the web application.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the data processed in the web application.",
 		FalsePositives: "When the technical asset " +
 			"is not accessed via a browser-like component (i.e not by a human user initiating the request that " +
 			"gets passed through all components until it reaches the web application) this can be considered a false positive.",

--- a/pkg/security/risks/builtin/ldap-injection-rule.go
+++ b/pkg/security/risks/builtin/ldap-injection-rule.go
@@ -15,7 +15,7 @@ func (*LdapInjectionRule) Category() types.RiskCategory {
 		Id:    "ldap-injection",
 		Title: "LDAP-Injection",
 		Description: "When an LDAP server is accessed LDAP-Injection risks might arise. " +
-			"The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed or stored.",
+			"The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed.",
 		Impact:     "If this risk remains unmitigated, attackers might be able to modify LDAP queries and access more data from the LDAP server than allowed.",
 		ASVS:       "V5 - Validation, Sanitization and Encoding Verification Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html",
@@ -27,7 +27,7 @@ func (*LdapInjectionRule) Category() types.RiskCategory {
 		Function:       types.Development,
 		STRIDE:         types.Tampering,
 		DetectionLogic: "In-scope clients accessing LDAP servers via typical LDAP access protocols.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed or stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the LDAP server itself and of the data assets processed.",
 		FalsePositives: "LDAP server queries by search values not consisting of parts controllable by the caller can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/missing-authentication-rule.go
+++ b/pkg/security/risks/builtin/missing-authentication-rule.go
@@ -14,7 +14,7 @@ func (*MissingAuthenticationRule) Category() types.RiskCategory {
 	return types.RiskCategory{
 		Id:          "missing-authentication",
 		Title:       "Missing Authentication",
-		Description: "Technical assets (especially multi-tenant systems) should authenticate incoming requests when the asset processes or stores sensitive data. ",
+		Description: "Technical assets (especially multi-tenant systems) should authenticate incoming requests when the asset processes sensitive data. ",
 		Impact:      "If this risk is unmitigated, attackers might be able to access or modify sensitive data in an unauthenticated way.",
 		ASVS:        "V2 - Authentication Verification Requirements",
 		CheatSheet:  "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html",
@@ -24,7 +24,7 @@ func (*MissingAuthenticationRule) Category() types.RiskCategory {
 		Check:    "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function: types.Architecture,
 		STRIDE:   types.ElevationOfPrivilege,
-		DetectionLogic: "In-scope technical assets (except " + types.LoadBalancer.String() + ", " + types.ReverseProxy.String() + ", " + types.ServiceRegistry.String() + ", " + types.WAF.String() + ", " + types.IDS.String() + ", and " + types.IPS.String() + " and in-process calls) should authenticate incoming requests when the asset processes or stores " +
+		DetectionLogic: "In-scope technical assets (except " + types.LoadBalancer.String() + ", " + types.ReverseProxy.String() + ", " + types.ServiceRegistry.String() + ", " + types.WAF.String() + ", " + types.IDS.String() + ", and " + types.IPS.String() + " and in-process calls) should authenticate incoming requests when the asset processes " +
 			"sensitive data. This is especially the case for all multi-tenant assets (there even non-sensitive ones).",
 		RiskAssessment: "The risk rating (medium or high) " +
 			"depends on the sensitivity of the data sent across the communication link. Monitoring callers are exempted from this risk.",

--- a/pkg/security/risks/builtin/missing-cloud-hardening-rule.go
+++ b/pkg/security/risks/builtin/missing-cloud-hardening-rule.go
@@ -35,7 +35,7 @@ func (*MissingCloudHardeningRule) Category() types.RiskCategory {
 		Function:       types.Operations,
 		STRIDE:         types.Tampering,
 		DetectionLogic: "In-scope cloud components (either residing in cloud trust boundaries or more specifically tagged with cloud provider types).",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Cloud components not running parts of the target architecture can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/missing-file-validation-rule.go
+++ b/pkg/security/risks/builtin/missing-file-validation-rule.go
@@ -28,7 +28,7 @@ func (*MissingFileValidationRule) Category() types.RiskCategory {
 		Function:       types.Development,
 		STRIDE:         types.Spoofing,
 		DetectionLogic: "In-scope technical assets with custom-developed code accepting file data formats.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Fully trusted (i.e. cryptographically signed or similar) files can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/missing-hardening-rule.go
+++ b/pkg/security/risks/builtin/missing-hardening-rule.go
@@ -32,7 +32,7 @@ func (r *MissingHardeningRule) Category() types.RiskCategory {
 		STRIDE:   types.Tampering,
 		DetectionLogic: "In-scope technical assets with RAA values of " + strconv.Itoa(r.raaLimit) + " % or higher. " +
 			"Generally for high-value targets like data stores, application servers, identity providers and ERP systems this limit is reduced to " + strconv.Itoa(r.raaLimitReduced) + " %",
-		RiskAssessment:             "The risk rating depends on the sensitivity of the data processed or stored in the technical asset.",
+		RiskAssessment:             "The risk rating depends on the sensitivity of the data processed in the technical asset.",
 		FalsePositives:             "Usually no false positives.",
 		ModelFailurePossibleReason: false,
 		CWE:                        16,

--- a/pkg/security/risks/builtin/missing-identity-store-rule.go
+++ b/pkg/security/risks/builtin/missing-identity-store-rule.go
@@ -27,7 +27,7 @@ func (*MissingIdentityStoreRule) Category() types.RiskCategory {
 		STRIDE:         types.Spoofing,
 		DetectionLogic: "Models with authenticated data-flows authorized via end user identity missing an in-scope identity store.",
 		RiskAssessment: "The risk rating depends on the sensitivity of the end user-identity authorized technical assets and " +
-			"their data assets processed and stored.",
+			"their data assets processed.",
 		FalsePositives: "Models only offering data/services without any real authentication need " +
 			"can be considered as false positives after individual review.",
 		ModelFailurePossibleReason: true,

--- a/pkg/security/risks/builtin/missing-vault-rule.go
+++ b/pkg/security/risks/builtin/missing-vault-rule.go
@@ -28,7 +28,7 @@ func (*MissingVaultRule) Category() types.RiskCategory {
 		Function:       types.Architecture,
 		STRIDE:         types.InformationDisclosure,
 		DetectionLogic: "Models without a Vault (Secret Storage).",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Models where no technical assets have any kind of sensitive config data to protect " +
 			"can be considered as false positives after individual review.",
 		ModelFailurePossibleReason: true,

--- a/pkg/security/risks/builtin/missing-waf-rule.go
+++ b/pkg/security/risks/builtin/missing-waf-rule.go
@@ -27,7 +27,7 @@ func (*MissingWafRule) Category() types.RiskCategory {
 		Function:       types.Operations,
 		STRIDE:         types.Tampering,
 		DetectionLogic: "In-scope web-services and/or web-applications accessed across a network trust boundary not having a Web Application Firewall (WAF) in front of them.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Targets only accessible via WAFs or reverse proxies containing a WAF component (like ModSecurity) can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/path-traversal-rule.go
+++ b/pkg/security/risks/builtin/path-traversal-rule.go
@@ -15,7 +15,7 @@ func (*PathTraversalRule) Category() types.RiskCategory {
 		Id:    "path-traversal",
 		Title: "Path-Traversal",
 		Description: "When a filesystem is accessed Path-Traversal or Local-File-Inclusion (LFI) risks might arise. " +
-			"The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed or stored.",
+			"The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		Impact: "If this risk is unmitigated, attackers might be able to read sensitive files (configuration data, key/credential files, deployment files, " +
 			"business data files, etc.) from the filesystem of affected components.",
 		ASVS:       "V12 - File and Resources Verification Requirements",

--- a/pkg/security/risks/builtin/search-query-injection-rule.go
+++ b/pkg/security/risks/builtin/search-query-injection-rule.go
@@ -30,7 +30,7 @@ func (*SearchQueryInjectionRule) Category() types.RiskCategory {
 		Function:       types.Development,
 		STRIDE:         types.Tampering,
 		DetectionLogic: "In-scope clients accessing search engine servers via typical search access protocols.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the search engine server itself and of the data assets processed or stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the search engine server itself and of the data assets processed.",
 		FalsePositives: "Server engine queries by search values not consisting of parts controllable by the caller can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/service-registry-poisoning-rule.go
+++ b/pkg/security/risks/builtin/service-registry-poisoning-rule.go
@@ -26,7 +26,7 @@ func (*ServiceRegistryPoisoningRule) Category() types.RiskCategory {
 		STRIDE:         types.Spoofing,
 		DetectionLogic: "In-scope service registries.",
 		RiskAssessment: "The risk rating depends on the sensitivity of the technical assets accessing the service registry " +
-			"as well as the data assets processed or stored.",
+			"as well as the data assets processed.",
 		FalsePositives: "Service registries not used for service discovery " +
 			"can be considered as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/sql-nosql-injection-rule.go
+++ b/pkg/security/risks/builtin/sql-nosql-injection-rule.go
@@ -15,7 +15,7 @@ func (*SqlNoSqlInjectionRule) Category() types.RiskCategory {
 		Id:    "sql-nosql-injection",
 		Title: "SQL/NoSQL-Injection",
 		Description: "When a database is accessed via database access protocols SQL/NoSQL-Injection risks might arise. " +
-			"The risk rating depends on the sensitivity technical asset itself and of the data assets processed or stored.",
+			"The risk rating depends on the sensitivity technical asset itself and of the data assets processed.",
 		Impact:     "If this risk is unmitigated, attackers might be able to modify SQL/NoSQL queries to steal and modify data and eventually further escalate towards a deeper system penetration via code executions.",
 		ASVS:       "V5 - Validation, Sanitization and Encoding Verification Requirements",
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",

--- a/pkg/security/risks/builtin/unencrypted-asset-rule.go
+++ b/pkg/security/risks/builtin/unencrypted-asset-rule.go
@@ -30,6 +30,7 @@ func (*UnencryptedAssetRule) Category() types.RiskCategory {
 			"storing data assets rated at least as " + types.Confidential.String() + " or " + types.Critical.String() + ". " +
 			"For technical assets storing data assets rated as " + types.StrictlyConfidential.String() + " or " + types.MissionCritical.String() + " the " +
 			"encryption must be of type " + types.DataWithEndUserIndividualKey.String() + ".",
+		// NOTE: the risk assesment does not only consider the CIs of the *stored* data-assets
 		RiskAssessment:             "Depending on the confidentiality rating of the stored data-assets either medium or high risk.",
 		FalsePositives:             "When all sensitive data stored within the asset is already fully encrypted on document or data level.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/unnecessary-data-asset-rule.go
+++ b/pkg/security/risks/builtin/unnecessary-data-asset-rule.go
@@ -16,7 +16,7 @@ func (*UnnecessaryDataAssetRule) Category() types.RiskCategory {
 	return types.RiskCategory{
 		Id:    "unnecessary-data-asset",
 		Title: "Unnecessary Data Asset",
-		Description: "When a data asset is not processed or stored by any data assets and also not transferred by any " +
+		Description: "When a data asset is not processed by any data assets and also not transferred by any " +
 			"communication links, this is an indicator for an unnecessary data asset (or for an incomplete model).",
 		Impact: "If this risk is unmitigated, attackers might be able to access unnecessary data assets using " +
 			"other vulnerabilities.",
@@ -27,7 +27,7 @@ func (*UnnecessaryDataAssetRule) Category() types.RiskCategory {
 		Check:      "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function:   types.Architecture,
 		STRIDE:     types.ElevationOfPrivilege,
-		DetectionLogic: "Modelled data assets not processed or stored by any data assets and also not transferred by any " +
+		DetectionLogic: "Modelled data assets not processed by any data assets and also not transferred by any " +
 			"communication links.",
 		RiskAssessment:             types.LowSeverity.String(),
 		FalsePositives:             "Usually no false positives as this looks like an incomplete model.",

--- a/pkg/security/risks/builtin/unnecessary-data-transfer-rule.go
+++ b/pkg/security/risks/builtin/unnecessary-data-transfer-rule.go
@@ -24,7 +24,7 @@ func (*UnnecessaryDataTransferRule) Category() types.RiskCategory {
 		CheatSheet: "https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html",
 		Action:     "Attack Surface Reduction",
 		Mitigation: "Try to avoid sending or receiving sensitive data assets which are not required (i.e. neither " +
-			"processed or stored) by the involved technical asset.",
+			"processed) by the involved technical asset.",
 		Check:    "Are recommendations from the linked cheat sheet and referenced ASVS chapter applied?",
 		Function: types.Architecture,
 		STRIDE:   types.ElevationOfPrivilege,
@@ -35,7 +35,7 @@ func (*UnnecessaryDataTransferRule) Category() types.RiskCategory {
 			"either " + types.LowSeverity.String() + " or " + types.MediumSeverity.String() + ".",
 		FalsePositives: "Technical assets missing the model entries of either processing or storing the mentioned data assets " +
 			"can be considered as false positives (incomplete models) after individual review. These should then be addressed by " +
-			"completing the model so that all necessary data assets are processed and/or stored by the technical asset involved.",
+			"completing the model so that all necessary data assets are processed by the technical asset involved.",
 		ModelFailurePossibleReason: true,
 		CWE:                        1008,
 	}

--- a/pkg/security/risks/builtin/unnecessary-technical-asset-rule.go
+++ b/pkg/security/risks/builtin/unnecessary-technical-asset-rule.go
@@ -14,7 +14,7 @@ func (*UnnecessaryTechnicalAssetRule) Category() types.RiskCategory {
 	return types.RiskCategory{
 		Id:    "unnecessary-technical-asset",
 		Title: "Unnecessary Technical Asset",
-		Description: "When a technical asset does not process or store any data assets, this is " +
+		Description: "When a technical asset does not process any data assets, this is " +
 			"an indicator for an unnecessary technical asset (or for an incomplete model). " +
 			"This is also the case if the asset has no communication links (either outgoing or incoming).",
 		Impact:                     "If this risk is unmitigated, attackers might be able to target unnecessary technical assets.",

--- a/pkg/security/risks/builtin/untrusted-deserialization-rule.go
+++ b/pkg/security/risks/builtin/untrusted-deserialization-rule.go
@@ -30,7 +30,7 @@ func (*UntrustedDeserializationRule) Category() types.RiskCategory {
 		Function:       types.Architecture,
 		STRIDE:         types.Tampering,
 		DetectionLogic: "In-scope technical assets accepting serialization data formats (including EJB and RMI protocols).",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored.",
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed.",
 		FalsePositives: "Fully trusted (i.e. cryptographically signed or similar) data deserialized can be considered " +
 			"as false positives after individual review.",
 		ModelFailurePossibleReason: false,

--- a/pkg/security/risks/builtin/xml-external-entity-rule.go
+++ b/pkg/security/risks/builtin/xml-external-entity-rule.go
@@ -27,7 +27,7 @@ func (*XmlExternalEntityRule) Category() types.RiskCategory {
 		Function:       types.Development,
 		STRIDE:         types.InformationDisclosure,
 		DetectionLogic: "In-scope technical assets accepting XML data formats.",
-		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed and stored. " +
+		RiskAssessment: "The risk rating depends on the sensitivity of the technical asset itself and of the data assets processed. " +
 			"Also for cloud-based environments the exploitation impact is at least medium, as cloud backend services can be attacked via SSRF (and XXE vulnerabilities are often also SSRF vulnerabilities).",
 		FalsePositives: "Fully trusted (i.e. cryptographically signed or similar) XML data can be considered " +
 			"as false positives after individual review.",

--- a/pkg/security/types/data_asset.go
+++ b/pkg/security/types/data_asset.go
@@ -92,9 +92,6 @@ func (what DataAsset) IsDataBreachPotentialStillAtRisk(parsedModel *ParsedModel)
 			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsProcessed, what.Id) {
 				return true
 			}
-			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsStored, what.Id) {
-				return true
-			}
 		}
 	}
 	return false
@@ -105,12 +102,6 @@ func (what DataAsset) IdentifiedDataBreachProbability(parsedModel *ParsedModel) 
 	for _, risk := range AllRisks(parsedModel) {
 		for _, techAsset := range risk.DataBreachTechnicalAssetIDs {
 			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsProcessed, what.Id) {
-				if risk.DataBreachProbability > highestProbability {
-					highestProbability = risk.DataBreachProbability
-					break
-				}
-			}
-			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsStored, what.Id) {
 				if risk.DataBreachProbability > highestProbability {
 					highestProbability = risk.DataBreachProbability
 					break
@@ -131,12 +122,6 @@ func (what DataAsset) IdentifiedDataBreachProbabilityStillAtRisk(parsedModel *Pa
 					break
 				}
 			}
-			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsStored, what.Id) {
-				if risk.DataBreachProbability > highestProbability {
-					highestProbability = risk.DataBreachProbability
-					break
-				}
-			}
 		}
 	}
 	return highestProbability
@@ -150,10 +135,6 @@ func (what DataAsset) IdentifiedDataBreachProbabilityRisksStillAtRisk(parsedMode
 				result = append(result, risk)
 				break
 			}
-			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsStored, what.Id) {
-				result = append(result, risk)
-				break
-			}
 		}
 	}
 	return result
@@ -164,10 +145,6 @@ func (what DataAsset) IdentifiedDataBreachProbabilityRisks(parsedModel *ParsedMo
 	for _, risk := range AllRisks(parsedModel) {
 		for _, techAsset := range risk.DataBreachTechnicalAssetIDs {
 			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsProcessed, what.Id) {
-				result = append(result, risk)
-				break
-			}
-			if contains(parsedModel.TechnicalAssets[techAsset].DataAssetsStored, what.Id) {
 				result = append(result, risk)
 				break
 			}

--- a/pkg/security/types/technical_asset.go
+++ b/pkg/security/types/technical_asset.go
@@ -110,12 +110,6 @@ func (what TechnicalAsset) HighestConfidentiality(parsedModel *ParsedModel) Conf
 			highest = dataAsset.Confidentiality
 		}
 	}
-	for _, dataId := range what.DataAssetsStored {
-		dataAsset := parsedModel.DataAssets[dataId]
-		if dataAsset.Confidentiality > highest {
-			highest = dataAsset.Confidentiality
-		}
-	}
 	return highest
 }
 
@@ -163,24 +157,12 @@ func (what TechnicalAsset) HighestIntegrity(model *ParsedModel) Criticality {
 			highest = dataAsset.Integrity
 		}
 	}
-	for _, dataId := range what.DataAssetsStored {
-		dataAsset := model.DataAssets[dataId]
-		if dataAsset.Integrity > highest {
-			highest = dataAsset.Integrity
-		}
-	}
 	return highest
 }
 
 func (what TechnicalAsset) HighestAvailability(model *ParsedModel) Criticality {
 	highest := what.Availability
 	for _, dataId := range what.DataAssetsProcessed {
-		dataAsset := model.DataAssets[dataId]
-		if dataAsset.Availability > highest {
-			highest = dataAsset.Availability
-		}
-	}
-	for _, dataId := range what.DataAssetsStored {
 		dataAsset := model.DataAssets[dataId]
 		if dataAsset.Availability > highest {
 			highest = dataAsset.Availability
@@ -238,13 +220,7 @@ func (what TechnicalAsset) IsZero() bool {
 }
 
 func (what TechnicalAsset) ProcessesOrStoresDataAsset(dataAssetId string) bool {
-	if contains(what.DataAssetsProcessed, dataAssetId) {
-		return true
-	}
-	if contains(what.DataAssetsStored, dataAssetId) {
-		return true
-	}
-	return false
+	return contains(what.DataAssetsProcessed, dataAssetId)
 }
 
 /*

--- a/support/schema.json
+++ b/support/schema.json
@@ -535,7 +535,7 @@
             "type": "boolean"
           },
           "data_assets_processed": {
-            "description": "Data assets processed",
+            "description": "Data assets processed; ; all data assets stored or sent or received via a communication link (be it as a source or a target) are implicitly also processed and do not need to be listed here.",
             "type": [
               "array",
               "null"
@@ -745,9 +745,7 @@
                 "vpn",
                 "ip_filtered",
                 "readonly",
-                "usage",
-                "data_assets_sent",
-                "data_assets_received"
+                "usage"
               ]
             }
           }


### PR DESCRIPTION
The PR is copied and manually applied from https://github.com/Threagile/threagile/pull/18, for any discussions if it help to clarify please take a look at the original 

> [aceg1k](https://github.com/aceg1k)
> aceg1k commented [on Jun 29, 2021](https://github.com/Threagile/threagile/pull/18#issue-933074680)
> Hi,
> 
> thank you very much for your great work on this project, I hope it is still active and open for pull requests.
> 
> Rationale
> Whenever data assets are stored, sent or received by a technical asset they are also processed in some way by that technical asset. This leads to tight coupling of data_assets_processed with data_assets_stored, data_assets_sent and data_assets_received (relating to both, outgoing and incoming communication links). IMHO data_assets_processed is of almost no practical use, when a data asset processed is not stored and not transferred somewhere.
> 
> Proposal
> Infer data_assets_processed based on data assets stored and data assets used in outgoing and incoming communication links and do not require data_assets_processed to be set and continuously maintained.
> 
> As a stored data asset always implies a processed data asset some of the code became redundant and was removed.
> 
> I look forward to your feedback!