### PR TITLE
Infer CIA ratings of tech assets #19

### DIFF
--- a/pkg/model/parse.go
+++ b/pkg/model/parse.go
@@ -334,6 +334,32 @@ func ParseModel(modelInput *input.Model, builtinRiskRules map[string]risks.RiskR
 		}
 	}
 
+	// If CIA was not set (i.e. equals -1) it is implicitly set to its highest calculated value
+	for id, techAsset := range parsedModel.TechnicalAssets {
+		if techAsset.Confidentiality < 0 {
+			techAsset.Confidentiality = techAsset.HighestConfidentiality(&parsedModel)
+			if techAsset.Confidentiality < 0 {
+				// no data asset is processed or stored, thus falling back to the lowest level
+				techAsset.Confidentiality = types.Public
+			}
+		}
+		if techAsset.Integrity < 0 {
+			techAsset.Integrity = techAsset.HighestIntegrity(&parsedModel)
+			if techAsset.Integrity < 0 {
+				// no data asset is processed or stored, thus falling back to the lowest level
+				techAsset.Integrity = types.Archive
+			}
+		}
+		if techAsset.Availability < 0 {
+			techAsset.Availability = techAsset.HighestAvailability(&parsedModel)
+			if techAsset.Availability < 0 {
+				// no data asset is processed or stored, thus falling back to the lowest level
+				techAsset.Availability = types.Archive
+			}
+		}
+		parsedModel.TechnicalAssets[id] = techAsset
+	}
+
 	// Trust Boundaries ===============================================================================
 	checklistToAvoidAssetBeingModeledInMultipleTrustBoundaries := make(map[string]bool)
 	parsedModel.TrustBoundaries = make(map[string]types.TrustBoundary)


### PR DESCRIPTION
The PR is copied and manually applied from https://github.com/Threagile/threagile/pull/19, for any discussions if it help to clarify please take a look at the original

> [aceg1k](https://github.com/aceg1k) commented [on Jul 10, 2021](https://github.com/Threagile/threagile/pull/19#issue-941313293) • 
> Hi,
> 
> just another pull request from my side.
> 
> Rationale
> Confidentiality, Integrity and Availability (CIA) of a tech asset may be inferred from the data that tech asset processes.
> 
> Proposal
> Infer CIA based on the data assets processed. If CIA can not be inferred, i.e. if no data asset is processed (probably this rarely happens in practice), fall back to the lowest possible level. If a value for CIA is set, it takes precedence.